### PR TITLE
Fixes an Incorrect argument label with swift and makes app universal (supports ipad resolution)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,68 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output

--- a/Swift-LightBlue.xcodeproj/project.pbxproj
+++ b/Swift-LightBlue.xcodeproj/project.pbxproj
@@ -561,6 +561,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Swift-LightBlue/Swift-LightBlue-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -579,6 +580,7 @@
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Swift-LightBlue/Swift-LightBlue-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Swift-LightBlue/EditValueController.swift
+++ b/Swift-LightBlue/EditValueController.swift
@@ -37,7 +37,7 @@ class EditValueController: UIViewController, BluetoothDelegate {
                     hexString = "0" + hexString
                 }
                 let data = hexString.dataFromHexadecimalString()
-                self.bluetoothManager.writeValue(data: data!, forCahracteristic: self.characteristic!, type: self.writeType!)
+                self.bluetoothManager.writeValue(data: data!, forCharacteristic: self.characteristic!, type: self.writeType!)
                 self.navigationController?.popViewController(animated: true)
             }
         }


### PR DESCRIPTION
I added default swift project gitignore (for some better output with `git status`)

I opened the project and had the following error:

> Swift-LightBlue/Swift-LightBlue/EditValueController.swift:40:49: Incorrect argument label in call (have 'data:forCahracteristic:type:', expected 'data:forCharacteristic:type:')

xcode proposed an auto fix (which worked):

<img width="1099" alt="fix" src="https://user-images.githubusercontent.com/1264761/29720452-fa2982c8-8987-11e7-9fa5-4e5647293cb2.png">

I also updated the config to make it Universal so it displays correctly on ipad:

![ipad-fixed](https://user-images.githubusercontent.com/1264761/29720515-27f317d2-8988-11e7-817c-f9308586f377.png)

Very nice and handy project. Used it to understand how to write characteristics, I could follow the steps with breakpoints, love it 👍 